### PR TITLE
Added option to use autocorrect on artist.getInfo

### DIFF
--- a/lib/rockstar/artist.rb
+++ b/lib/rockstar/artist.rb
@@ -60,7 +60,7 @@ module Rockstar
   class Artist < Base
     attr_accessor :name, :mbid, :listenercount, :playcount, :rank, :url, :thumbnail
     attr_accessor :summary, :content, :images, :count, :streamable, :tags
-    attr_accessor :chartposition
+    attr_accessor :chartposition, :autocorrect
 
     # used for similar artists
     attr_accessor :match
@@ -80,7 +80,8 @@ module Rockstar
     def initialize(name, o={})
       raise ArgumentError, "Name or mbid is required" if name.blank? && o[:mbid].blank?
       @name = name unless name.blank?
-      @mbid = o[:mbid] unless o[:mbid].blank?
+      @mbid = o.fetch :mbid, nil
+      @autocorrect = o.fetch :autocorrect, nil
 
       options = {:include_info => false}.merge(o)
       load_info if options[:include_info]
@@ -89,6 +90,7 @@ module Rockstar
     def load_info(xml=nil)
       unless xml
         params = @mbid.blank? ? {:artist => @name} : {:mbid => @mbid}
+        params.merge!(autocorrect: 1) if @autocorrect
 
         doc = self.class.fetch_and_parse("artist.getInfo", params)
         xml = (doc / :artist).first

--- a/test/fixtures/xml/artist/getinfo_artist_metalica_autocorrect_1.xml
+++ b/test/fixtures/xml/artist/getinfo_artist_metalica_autocorrect_1.xml
@@ -1,0 +1,145 @@
+<lfm status="ok">
+  <artist>
+    <name>Metallica</name>
+    <mbid>65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab</mbid>
+    <bandmembers>
+      <member>
+        <name>James Hetfield</name>
+        <yearfrom>1981</yearfrom>
+      </member>
+      <member>
+        <name>Lars Ulrich</name>
+        <yearfrom>1981</yearfrom>
+      </member>
+      <member>
+        <name>Kirk Hammett</name>
+        <yearfrom>1983</yearfrom>
+      </member>
+      <member>
+        <name>Robert Trujillo</name>
+        <yearfrom>2003</yearfrom>
+      </member>
+    </bandmembers>
+    <url>http://www.last.fm/music/Metallica</url>
+    <image size="small">http://userserve-ak.last.fm/serve/34/3438692.jpg</image>
+    <image size="medium">http://userserve-ak.last.fm/serve/64/3438692.jpg</image>
+    <image size="large">http://userserve-ak.last.fm/serve/126/3438692.jpg</image>
+    <image size="extralarge">http://userserve-ak.last.fm/serve/252/3438692.jpg</image>
+    <image size="mega">
+      http://userserve-ak.last.fm/serve/500/3438692/Metallica+band.jpg
+    </image>
+    <streamable>0</streamable>
+    <ontour>0</ontour>
+    <stats>
+      <listeners>2615890</listeners>
+      <playcount>240102218</playcount>
+    </stats>
+    <similar>
+      <artist>
+        <name>Megadeth</name>
+        <url>http://www.last.fm/music/Megadeth</url>
+        <image size="small">http://userserve-ak.last.fm/serve/34/100238499.jpg</image>
+        <image size="medium">http://userserve-ak.last.fm/serve/64/100238499.jpg</image>
+        <image size="large">
+          http://userserve-ak.last.fm/serve/126/100238499.jpg
+        </image>
+        <image size="extralarge">
+          http://userserve-ak.last.fm/serve/252/100238499.jpg
+        </image>
+        <image size="mega">
+          http://userserve-ak.last.fm/serve/500/100238499/Megadeth+1604698_10152029114187330_5803.jpg
+        </image>
+      </artist>
+      <artist>
+        <name>Pantera</name>
+        <url>http://www.last.fm/music/Pantera</url>
+        <image size="small">http://userserve-ak.last.fm/serve/34/29176179.jpg</image>
+        <image size="medium">http://userserve-ak.last.fm/serve/64/29176179.jpg</image>
+        <image size="large">http://userserve-ak.last.fm/serve/126/29176179.jpg</image>
+        <image size="extralarge">http://userserve-ak.last.fm/serve/252/29176179.jpg</image>
+        <image size="mega">
+          http://userserve-ak.last.fm/serve/_/29176179/Pantera+6838373550px.jpg
+        </image>
+      </artist>
+      <artist>
+        <name>Slayer</name>
+        <url>http://www.last.fm/music/Slayer</url>
+        <image size="small">http://userserve-ak.last.fm/serve/34/8428755.jpg</image>
+        <image size="medium">http://userserve-ak.last.fm/serve/64/8428755.jpg</image>
+        <image size="large">http://userserve-ak.last.fm/serve/126/8428755.jpg</image>
+        <image size="extralarge">http://userserve-ak.last.fm/serve/252/8428755.jpg</image>
+        <image size="mega">
+          http://userserve-ak.last.fm/serve/500/8428755/Slayer.jpg
+        </image>
+      </artist>
+      <artist>
+        <name>Iron Maiden</name>
+        <url>http://www.last.fm/music/Iron+Maiden</url>
+        <image size="small">http://userserve-ak.last.fm/serve/34/330947.jpg</image>
+        <image size="medium">http://userserve-ak.last.fm/serve/64/330947.jpg</image>
+        <image size="large">http://userserve-ak.last.fm/serve/126/330947.jpg</image>
+        <image size="extralarge">http://userserve-ak.last.fm/serve/252/330947.jpg</image>
+        <image size="mega">
+          http://userserve-ak.last.fm/serve/500/330947/Iron+Maiden.jpg
+        </image>
+      </artist>
+      <artist>
+        <name>Lou Reed & Metallica</name>
+        <url>http://www.last.fm/music/Lou+Reed+&+Metallica</url>
+        <image size="small">http://userserve-ak.last.fm/serve/34/71171232.png</image>
+        <image size="medium">http://userserve-ak.last.fm/serve/64/71171232.png</image>
+        <image size="large">http://userserve-ak.last.fm/serve/126/71171232.png</image>
+        <image size="extralarge">http://userserve-ak.last.fm/serve/252/71171232.png</image>
+        <image size="mega">
+          http://userserve-ak.last.fm/serve/500/71171232/Lou+Reed++Metallica+loumet.png
+        </image>
+      </artist>
+    </similar>
+    <tags>
+      <tag>
+        <name>thrash metal</name>
+        <url>http://www.last.fm/tag/thrash%20metal</url>
+      </tag>
+      <tag>
+        <name>metal</name>
+        <url>http://www.last.fm/tag/metal</url>
+      </tag>
+      <tag>
+        <name>heavy metal</name>
+        <url>http://www.last.fm/tag/heavy%20metal</url>
+      </tag>
+      <tag>
+        <name>hard rock</name>
+        <url>http://www.last.fm/tag/hard%20rock</url>
+      </tag>
+      <tag>
+        <name>rock</name>
+        <url>http://www.last.fm/tag/rock</url>
+      </tag>
+    </tags>
+    <bio>
+      <links>
+        <link rel="original" href="http://www.last.fm/music/Metallica/+wiki"/>
+      </links>
+      <published>Tue, 13 May 2014 14:12:57 +0000</published>
+      <summary>
+        <![CDATA[
+        Metallica is an American metal band formed in 1981 in Los Angeles, California, United States when drummer Lars Ulrich posted an advertisement in The Recycler. Metallica’s line-up originally consisted of Ulrich, rhythm guitarist and vocalist James Hetfield, and lead guitarist Dave Mustaine. Mustaine was later fired due to problems with alcoholism and drug addiction - he went on to form the band Megadeth. Exodus guitarist Kirk Hammett took his place. <a href="http://www.last.fm/music/Metallica">Read more about Metallica on Last.fm</a>.
+        ]]>
+      </summary>
+      <content>
+        <![CDATA[
+        Metallica is an American metal band formed in 1981 in Los Angeles, California, United States when drummer Lars Ulrich posted an advertisement in The Recycler. Metallica’s line-up originally consisted of Ulrich, rhythm guitarist and vocalist James Hetfield, and lead guitarist Dave Mustaine. Mustaine was later fired due to problems with alcoholism and drug addiction - he went on to form the band Megadeth. Exodus guitarist Kirk Hammett took his place. <a href="http://www.last.fm/music/Metallica">Read more about Metallica on Last.fm</a>. User-contributed text is available under the Creative Commons By-SA License and may also be available under the GNU FDL.
+        ]]>
+      </content>
+      <placeformed>Los Angeles, California, United States</placeformed>
+      <yearformed>1981</yearformed>
+      <formationlist>
+        <formation>
+          <yearfrom>1981</yearfrom>
+          <yearto/>
+        </formation>
+      </formationlist>
+    </bio>
+  </artist>
+</lfm>

--- a/test/unit/test_artist.rb
+++ b/test/unit/test_artist.rb
@@ -5,11 +5,11 @@ class TestArtist < Test::Unit::TestCase
   def setup
     @artist = Rockstar::Artist.new('Metallica')
   end
-  
+
   test 'should require name' do
     assert_raises(ArgumentError) { Rockstar::Artist.new('') }
   end
-  
+
   test "should know it's name" do
     assert_equal('Metallica', @artist.name)
   end
@@ -53,7 +53,7 @@ class TestArtist < Test::Unit::TestCase
     assert_equal('http://userserve-ak.last.fm/serve/126/598154.jpg', first.images['large'])
     assert_equal('yes', first.streamable)
   end
-  
+
   test 'should be able to find top fans' do
     assert_equal(["yIIyIIyIIy", "eliteveritas", "BrandonUCD", "Mithrandir93"], @artist.top_fans.collect(&:username)[0..3])
     first = @artist.top_fans.first
@@ -66,7 +66,7 @@ class TestArtist < Test::Unit::TestCase
     assert_equal('http://userserve-ak.last.fm/serve/252/40197285.jpg', first.images['extralarge'])
     assert_equal('707560000', first.weight)
   end
-  
+
   test 'should be able to find top tracks' do
     assert_equal(['Nothing Else Matters', 'Enter Sandman', 'One', 'Master Of Puppets'], @artist.top_tracks.collect(&:name)[0..3])
     first = @artist.top_tracks.first
@@ -74,7 +74,7 @@ class TestArtist < Test::Unit::TestCase
     assert_equal('', first.mbid)
     assert_equal('http://www.last.fm/music/Metallica/_/Nothing+Else+Matters', first.url)
   end
-  
+
   test 'should be able to find top albums' do
     assert_equal(["Master Of Puppets", "Death Magnetic", "Ride The Lightning"], @artist.top_albums.collect(&:name)[0..2])
     first = @artist.top_albums.first
@@ -83,9 +83,9 @@ class TestArtist < Test::Unit::TestCase
     assert_equal('http://www.last.fm/music/Metallica/Master+Of+Puppets', first.url)
     assert_equal('http://userserve-ak.last.fm/serve/34s/8622967.jpg', first.image(:small))
     assert_equal('http://userserve-ak.last.fm/serve/64s/8622967.jpg', first.image(:medium))
-    assert_equal('http://userserve-ak.last.fm/serve/126/8622967.jpg', first.image(:large))    
+    assert_equal('http://userserve-ak.last.fm/serve/126/8622967.jpg', first.image(:large))
   end
-  
+
   test 'should be able to find top tags' do
     assert_equal(['thrash metal', 'metal', 'heavy metal'], @artist.top_tags.collect(&:name)[0..2])
     first = @artist.top_tags.first
@@ -119,5 +119,11 @@ class TestArtist < Test::Unit::TestCase
     assert_equal("http://www.last.fm/music/Slayer", artist.url)
     assert_equal("72de5171-38cf-4734-bc8a-6ac374dea523", artist.mbid)
     assert_match(/Slayer's musical traits involve fast tremolo picking/, artist.summary)
+  end
+
+  test 'should be able to correct artist name' do
+    artist = Rockstar::Artist.new('metalica', :include_info => true, autocorrect: true)
+    assert_equal("Metallica", artist.name)
+    assert_equal("http://www.last.fm/music/Metallica", artist.url)
   end
 end


### PR DESCRIPTION
According to the [api documentation](http://www.last.fm/api/show/artist.getInfo), the autocorrect option corrects the
artist name if it was misspelled.
