### PR TITLE
Add optional parameter options to user.recent_tracks

### DIFF
--- a/lib/rockstar/user.rb
+++ b/lib/rockstar/user.rb
@@ -143,8 +143,10 @@ module Rockstar
       get_instance("user.getNeighbours", :neighbours, :user, {user: @username}, force)
     end
 
-    def recent_tracks(force=false)
-      get_instance("user.getRecentTracks", :recent_tracks, :track, {user: @username}, force)
+    def recent_tracks(force=false, options={})
+      options[:user] = @username
+
+      get_instance("user.getRecentTracks", :recent_tracks, :track, options, force)
     end
 
     def recent_loved_tracks(force=false)

--- a/test/fixtures/xml/user/getrecenttracks_from_1092587022_to_1092587040_user_jnunemaker.xml
+++ b/test/fixtures/xml/user/getrecenttracks_from_1092587022_to_1092587040_user_jnunemaker.xml
@@ -1,0 +1,16 @@
+<lfm status="ok">
+<recenttracks user="jnunemaker" page="1" perPage="10" totalPages="3572">
+<track>
+        <artist mbid="4eca1aa0-c79f-481b-af8a-4a2d6c41aa5c">Miranda Lambert</artist>
+<name>Maintain The Pain</name>
+<streamable>0</streamable>
+<mbid></mbid>
+<album mbid=""></album>
+<url>http://www.last.fm/music/Miranda+Lambert/_/Maintain+The+Pain</url>
+    <image size="small"></image>
+    <image size="medium"></image>
+    <image size="large"></image>
+    <image size="extralarge"></image>
+        <date uts="1092587022">15 Aug 2004, 16:23</date>
+</track<name />
+</recenttracks></lfm>

--- a/test/unit/test_user.rb
+++ b/test/unit/test_user.rb
@@ -161,6 +161,14 @@ class TestUser < Test::Unit::TestCase
     assert_equal('1276967182', first.date_uts)
   end
 
+  test 'should have recent tracks in time range' do
+    recent_tracks = @user.recent_tracks(false, from: '1092587022', to: '1092587040')
+    assert_equal(1, recent_tracks.size)
+    first = recent_tracks.first
+    assert_equal(Time.mktime(2004, 8, 15, 16, 23, 00), first.date)
+    assert_equal('1092587022', first.date_uts)
+  end
+
   test 'should have recent loved tracks' do
     assert_equal(50, @user.recent_loved_tracks.size)
     first = @user.recent_loved_tracks.first


### PR DESCRIPTION
The Last.fm API supports multiple optional parameters on the user.getRecentTracks endpoint like a time range with `from` and `to` or the maximum number of results like with `limit`. See: http://www.lastfm.de/api/show/user.getRecentTracks

This pull request adds an optional hash named `options` to the user.recent_tracks method that allows to set these parameter like so:

```
user.recent_tracks(_, from: '1438272581', to: '1439136780', limit: 200)
```