### PR TITLE
Add ability to use track search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development do
 end
 
 group :test do
+  gem "test-unit"
   gem "hpricot", ">= 0.4.0"
   gem "activesupport", ">=1.4.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,10 +46,13 @@ GEM
       multi_json (~> 1.0)
       multi_xml (~> 0.5)
       rack (~> 1.2)
+    power_assert (0.2.2)
     rack (1.5.2)
     rake (10.1.1)
     rdoc (4.1.1)
       json (~> 1.4)
+    test-unit (3.0.8)
+      power_assert
 
 PLATFORMS
   ruby
@@ -60,3 +63,4 @@ DEPENDENCIES
   i18n (>= 0.5.0)
   jeweler (>= 2.0.0)
   rake (>= 0.10.0)
+  test-unit

--- a/lib/rockstar/track.rb
+++ b/lib/rockstar/track.rb
@@ -70,6 +70,25 @@ module Rockstar
         doc.at("lfm")["status"]
       end
 
+      # Search a song
+      #
+      # limit (Optional) : The number of results to fetch per page. Defaults to 30.
+      # page (Optional) : The page number to fetch. Defaults to first page.
+      # track (Required) : The track name
+      # artist (Optional) : Narrow your search by specifying an artist.
+      def search(params = {})
+        query = {
+          track: params[:track]
+        }
+
+        query[:limit]  = params[:limit]  if params[:limit]
+        query[:page]   = params[:page]   if params[:page]
+        query[:track]  = params[:track]  if params[:track]
+        query[:artist] = params[:artist] if params[:artist]
+
+        get_instance('track.search', :search, :track, query, false)
+      end
+
       # Scrobble a song
       #
       # Possible parameters:

--- a/lib/rockstar/track.rb
+++ b/lib/rockstar/track.rb
@@ -77,6 +77,10 @@ module Rockstar
       # track (Required) : The track name
       # artist (Optional) : Narrow your search by specifying an artist.
       def search(params = {})
+        if params[:track].blank?
+          raise ArgumentError, "Missing required argument"
+        end
+
         query = {
           track: params[:track]
         }

--- a/test/fixtures/xml/track/search_track_Ishome_Wildness.xml
+++ b/test/fixtures/xml/track/search_track_Ishome_Wildness.xml
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<lfm status="ok">
+  <results>
+    <opensearch:Query role="request" startPage="1">
+  </opensearch:Query>
+    <opensearch:totalResults>0</opensearch:totalResults>
+    <opensearch:startIndex>0</opensearch:startIndex>
+    <opensearch:itemsPerPage>30</opensearch:itemsPerPage>
+    <trackmatches>
+      <track>
+        <name>Wildness</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>5763</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Ishome - Wildness</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Ishome+-+Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>41</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness (Original Mix)</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+(Original+Mix)</url>
+        <streamable>FIXME</streamable>
+        <listeners>34</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Ishome - Wildness</name>
+        <artist>[unknown]</artist>
+        <url>http://www.last.fm/music/%5Bunknown%5D/_/Ishome+-+Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>2</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/a918544951804982b0f9c589d34c760b.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/a918544951804982b0f9c589d34c760b.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/a918544951804982b0f9c589d34c760b.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/a918544951804982b0f9c589d34c760b.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness - Ishome - Confession</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+-+Ishome+-+Confession</url>
+        <streamable>FIXME</streamable>
+        <listeners>2</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness (CRAVERO remix)</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+(CRAVERO+remix)</url>
+        <streamable>FIXME</streamable>
+        <listeners>11</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness(Original Mix)</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness(Original+Mix)</url>
+        <streamable>FIXME</streamable>
+        <listeners>2</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Ishome - Wildness (Hypno Translation By Taiga)</name>
+        <artist>Taiga</artist>
+        <url>http://www.last.fm/music/Taiga/_/Ishome+-+Wildness+(Hypno+Translation+By+Taiga)</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/b3c653e67e5c4543c551cc7dc0440260.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/b3c653e67e5c4543c551cc7dc0440260.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/b3c653e67e5c4543c551cc7dc0440260.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/b3c653e67e5c4543c551cc7dc0440260.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>04 - wildness</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/04+-+wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness - Ishome</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+-+Ishome</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness (Hypno translation by Taiga)</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+(Hypno+translation+by+Taiga)</url>
+        <streamable>FIXME</streamable>
+        <listeners>2</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Ishome_-_Wildness</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Ishome_-_Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>04. Ishome - Wildness</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/04.+Ishome+-+Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>ishome 04 wildness</name>
+        <artist>[unknown]</artist>
+        <url>http://www.last.fm/music/%5Bunknown%5D/_/ishome+04+wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/a918544951804982b0f9c589d34c760b.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/a918544951804982b0f9c589d34c760b.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/a918544951804982b0f9c589d34c760b.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/a918544951804982b0f9c589d34c760b.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness - Equalyza</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+-+Equalyza</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness (Orginal Mix)</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+(Orginal+Mix)</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>04 Wildness (Альбом Confession)</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/04+Wildness+(%D0%90%D0%BB%D1%8C%D0%B1%D0%BE%D0%BC+Confession)</url>
+        <streamable>FIXME</streamable>
+        <listeners>2</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>04  Wildness</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/04++Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness (cut)</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+(cut)</url>
+        <streamable>FIXME</streamable>
+        <listeners>2</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>04 wildness</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/04+wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness - Volta</name>
+        <artist>Ishome</artist>
+        <url>http://www.last.fm/music/Ishome/_/Wildness+-+Volta</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">http://img2-ak.lst.fm/i/u/34s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="medium">http://img2-ak.lst.fm/i/u/64s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="large">http://img2-ak.lst.fm/i/u/174s/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <image size="extralarge">http://img2-ak.lst.fm/i/u/300x300/e66045bf61cf43c9c3ae544784e101e0.png</image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness</name>
+        <artist>≡  Ishome</artist>
+        <url>http://www.last.fm/music/%E2%89%A1++Ishome/_/Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>2</listeners>
+        <image size="small">
+      </image>
+        <image size="medium">
+      </image>
+        <image size="large">
+      </image>
+        <image size="extralarge">
+      </image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>wildness ]</name>
+        <artist>[ ishome</artist>
+        <url>http://www.last.fm/music/%5B+ishome/_/wildness+%5D</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">
+      </image>
+        <image size="medium">
+      </image>
+        <image size="large">
+      </image>
+        <image size="extralarge">
+      </image>
+        <mbid></mbid>
+      </track>
+      <track>
+        <name>Wildness</name>
+        <artist>═╬ Ishome</artist>
+        <url>http://www.last.fm/music/%E2%95%90%E2%95%AC+Ishome/_/Wildness</url>
+        <streamable>FIXME</streamable>
+        <listeners>1</listeners>
+        <image size="small">
+      </image>
+        <image size="medium">
+      </image>
+        <image size="large">
+      </image>
+        <image size="extralarge">
+      </image>
+        <mbid></mbid>
+      </track>
+    </trackmatches>
+  </results>
+</lfm>

--- a/test/unit/test_track.rb
+++ b/test/unit/test_track.rb
@@ -4,7 +4,7 @@ class TestTrack < Test::Unit::TestCase
 
   def setup
     @track = Rockstar::Track.new('Carrie Underwood', 'Before He Cheats')
-	@track1 = Rockstar::Track.new('Karrie Underwood', 'Before He Cheats')
+    @track1 = Rockstar::Track.new('Karrie Underwood', 'Before He Cheats')
   end
 
   test 'should require the artist name' do
@@ -25,11 +25,11 @@ class TestTrack < Test::Unit::TestCase
 
   test 'should be able to load track info' do
     @track.load_info
-	@track1.load_info
+    @track1.load_info
     assert_equal('http://www.last.fm/music/Carrie+Underwood/_/Before+He+Cheats', @track.url)
     assert_equal('1040848',  @track.playcount)
-	assert_equal(false, @track.now_playing?)
-	assert_equal(true, @track1.now_playing?)
+    assert_equal(false, @track.now_playing?)
+    assert_equal(true, @track1.now_playing?)
     assert_match(/named the 2007 Single of the Year by the Country Music Association/, @track.summary)
   end
 

--- a/test/unit/test_track_search.rb
+++ b/test/unit/test_track_search.rb
@@ -1,0 +1,19 @@
+require File.expand_path('../../test_helper.rb', __FILE__)
+
+class TestTrackSearch < Test::Unit::TestCase
+
+  def setup
+    @search = Rockstar::Track.search({ track: "Ishome Wildness" })
+    @first_track = @search.first
+  end
+
+  test 'raise missing parameter error in search' do
+    assert_raises(ArgumentError) { Rockstar::Track.search() }
+  end
+
+  test 'should know the name of first track' do
+    assert_equal('Wildness', @first_track.name)
+    assert_equal('Ishome', @first_track.artist)
+  end
+
+end


### PR DESCRIPTION
Track.search {}

options:
limit (Optional) : The number of results to fetch per page. Defaults to
30.
page (Optional) : The page number to fetch. Defaults to first page.
track (Required) : The track name
artist (Optional) : Narrow your search by specifying an artist.
